### PR TITLE
Feature/faster normal space filter

### DIFF
--- a/pointmatcher/DataPointsFilters/NormalSpace.cpp
+++ b/pointmatcher/DataPointsFilters/NormalSpace.cpp
@@ -46,7 +46,7 @@ NormalSpaceDataPointsFilter<T>::NormalSpaceDataPointsFilter(const Parameters& pa
 	nbSample{Parametrizable::get<std::size_t>("nbSample")},
 	seed{Parametrizable::get<std::size_t>("seed")},
 	epsilon{Parametrizable::get<T>("epsilon")},
-	nbBucket{std::size_t((2.0 * M_PI / epsilon) * (M_PI / epsilon))}
+	nbBucket{std::size_t(ceil(2.0 * M_PI / epsilon) * ceil(M_PI / epsilon))}
 {
 }
 
@@ -177,7 +177,11 @@ std::size_t NormalSpaceDataPointsFilter<T>::bucketIdx(T theta, T phi) const
 {
 	//Theta = polar angle in [0 ; pi] and Phi = azimuthal angle in [0 ; 2pi]
 	assert((theta >= 0.0) && (theta <= static_cast<T>(M_PI)) && (phi >= 0) && (phi <= 2.0*((float) static_cast<T>(M_PI))));
-	return static_cast<std::size_t>(theta / epsilon) * static_cast<std::size_t>(2. * M_PI / epsilon) + static_cast<std::size_t>(phi / epsilon);
+
+	// Wrap Theta at Pi
+	if (theta == static_cast<T>(M_PI)) { theta = 0.0; };
+	//                               block number           block size               element number
+	return static_cast<std::size_t>( floor(theta/epsilon) * ceil(2.0*M_PI/epsilon) + floor(phi/epsilon) );
 }
 
 template struct NormalSpaceDataPointsFilter<float>;

--- a/pointmatcher/DataPointsFilters/NormalSpace.cpp
+++ b/pointmatcher/DataPointsFilters/NormalSpace.cpp
@@ -98,15 +98,19 @@ void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 	///(1) put all points of the data into buckets based on their normal direction
 	for (int i = 0; i < nbPoints; ++i)
 	{
-		assert(normals.col(i).head(3).norm() == 1);
+		// Allow for slight approximiation errors
+		assert(normals.col(i).head(3).norm() >= 1.0-0.00001);
+		assert(normals.col(i).head(3).norm() <= 1.0+0.00001);
+		// Catch errors where theta will be NaN
+		assert((normals(2,i) <= 1.0) && (normals(2,i) >= -1.0));
 
 		//Theta = polar angle in [0 ; pi]
 		const T theta = std::acos(normals(2, i));
 		//Phi = azimuthal angle in [0 ; 2pi]
 		const T phi = std::fmod(std::atan2(normals(1, i), normals(0, i)) + 2. * M_PI, 2. * M_PI);
 
-		//assert(theta >= 0. and theta =< M_PI and phi >= 0. and phi <= 2.*M_PI);
-
+		// Catch normal space hasing errors
+		assert(bucketIdx(theta, phi) < nbBucket);
 		idBuckets[bucketIdx(theta, phi)].push_back(i);
 	}
 	///(2) uniformly pick points from all the buckets until the desired number of points is selected
@@ -172,6 +176,7 @@ template <typename T>
 std::size_t NormalSpaceDataPointsFilter<T>::bucketIdx(T theta, T phi) const
 {
 	//Theta = polar angle in [0 ; pi] and Phi = azimuthal angle in [0 ; 2pi]
+	assert((theta >= 0.0) && (theta <= static_cast<T>(M_PI)) && (phi >= 0) && (phi <= 2.0*((float) static_cast<T>(M_PI))));
 	return static_cast<std::size_t>(theta / epsilon) * static_cast<std::size_t>(2. * M_PI / epsilon) + static_cast<std::size_t>(phi / epsilon);
 }
 

--- a/pointmatcher/DataPointsFilters/NormalSpace.cpp
+++ b/pointmatcher/DataPointsFilters/NormalSpace.cpp
@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include "NormalSpace.h"
 
+#include <algorithm>
 #include <vector>
 #include <unordered_map>
 #include <random>
@@ -64,8 +65,6 @@ NormalSpaceDataPointsFilter<T>::filter(const DataPoints& input)
 template <typename T>
 void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 {
-	static const int alreadySampled = -1;
-
 	//check dimension
 	const std::size_t featDim = cloud.features.rows();
 	if(featDim < 4) //3D case support only
@@ -86,7 +85,6 @@ void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 	const auto& normals = cloud.getDescriptorViewByName("normals");
 
 	std::mt19937 gen(seed); //Standard mersenne_twister_engine seeded with seed
-	std::uniform_real_distribution<> uni01(0., 1.);
 
 	//bucketed normal space
 	std::vector<std::vector<int>> idBuckets; //stock int so we can marked selected with -1
@@ -95,62 +93,54 @@ void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 	std::vector<std::size_t> keepIndexes;
 	keepIndexes.reserve(nbSample);
 
+	// Generate a random sequence of indices so that elements are placed in buckets in random order
+	std::vector<std::size_t> randIdcs(nbPoints);
+	std::iota(randIdcs.begin(), randIdcs.end(), 0); // 0-nbPoints  TODO is there a way to do this with a generator?
+	std::random_shuffle(randIdcs.begin(), randIdcs.end());
+
 	///(1) put all points of the data into buckets based on their normal direction
-	for (int i = 0; i < nbPoints; ++i)
+	for (auto randIdx : randIdcs)
 	{
 		// Allow for slight approximiation errors
-		assert(normals.col(i).head(3).norm() >= 1.0-0.00001);
-		assert(normals.col(i).head(3).norm() <= 1.0+0.00001);
+		assert(normals.col(randIdx).head(3).norm() >= 1.0-0.00001);
+		assert(normals.col(randIdx).head(3).norm() <= 1.0+0.00001);
 		// Catch errors where theta will be NaN
-		assert((normals(2,i) <= 1.0) && (normals(2,i) >= -1.0));
+		assert((normals(2,randIdx) <= 1.0) && (normals(2,randIdx) >= -1.0));
 
 		//Theta = polar angle in [0 ; pi]
-		const T theta = std::acos(normals(2, i));
+		const T theta = std::acos(normals(2, randIdx));
 		//Phi = azimuthal angle in [0 ; 2pi]
-		const T phi = std::fmod(std::atan2(normals(1, i), normals(0, i)) + 2. * M_PI, 2. * M_PI);
+		const T phi = std::fmod(std::atan2(normals(1, randIdx), normals(0, randIdx)) + 2. * M_PI, 2. * M_PI);
 
 		// Catch normal space hasing errors
 		assert(bucketIdx(theta, phi) < nbBucket);
-		idBuckets[bucketIdx(theta, phi)].push_back(i);
+		idBuckets[bucketIdx(theta, phi)].push_back(randIdx);
 	}
+
+	// Remove empty buckets
+	idBuckets.erase(std::remove_if(idBuckets.begin(), idBuckets.end(),
+				[](const std::vector<int>& bucket) { return bucket.empty(); }),
+				idBuckets.end());
+
 	///(2) uniformly pick points from all the buckets until the desired number of points is selected
-	while(keepIndexes.size() < nbSample)
+	for (std::size_t i=0; i<nbSample; i++)
 	{
-		const T theta = std::acos(1 - 2 * uni01(gen));
-		const T phi = 2. * M_PI * uni01(gen);
-
-		std::vector<int>& curBucket = idBuckets[bucketIdx(theta, phi)];
-
-		//Check size
-		if(curBucket.empty())
-			continue;
-
-		const std::size_t bucketSize = curBucket.size();
-
-		//Check if not already all sampled
-		bool isEntireBucketSampled = true;
-		for(std::size_t id = 0; id < bucketSize and isEntireBucketSampled; ++id)
-		{
-			isEntireBucketSampled = isEntireBucketSampled and (curBucket[id] == alreadySampled);
-		}
-
-		if(isEntireBucketSampled)
-			continue;
+		// Get a random bucket
+		std::uniform_int_distribution<std::size_t> uniBucket(0,idBuckets.size()-1);
+		std::size_t curBucketIdx = uniBucket(gen);
+		std::vector<int>& curBucket = idBuckets[curBucketIdx];
 
 		///(3) A point is randomly picked in a bucket that contains multiple points
-		int idToKeep = 0;
-		std::size_t idInBucket = 0;
-		do
-		{
-			 idInBucket = static_cast<std::size_t>(bucketSize * uni01(gen));
-			 idToKeep = curBucket[idInBucket];
-
-		} while(idToKeep == alreadySampled);
-
+		int idToKeep = curBucket[curBucket.size()-1];
+		curBucket.pop_back();
 		keepIndexes.push_back(static_cast<std::size_t>(idToKeep));
 
-		curBucket[idInBucket] = alreadySampled; //set sampled flag
+		// Remove the bucket if it is empty
+		if (curBucket.empty()) {
+			idBuckets.erase(idBuckets.begin()+curBucketIdx);
+		}
 	}
+
 	//TODO: evaluate performances between this solution and sorting the indexes
 	// We build map of (old index to new index), in case we sample pts at the begining of the pointcloud
 	std::unordered_map<std::size_t, std::size_t> mapidx;

--- a/pointmatcher/DataPointsFilters/NormalSpace.h
+++ b/pointmatcher/DataPointsFilters/NormalSpace.h
@@ -50,7 +50,7 @@ struct NormalSpaceDataPointsFilter : public PointMatcher<T>::DataPointsFilter
 	typedef Parametrizable::ParameterDoc ParameterDoc;
 	typedef Parametrizable::ParametersDoc ParametersDoc;
 	typedef Parametrizable::InvalidParameter InvalidParameter;
-	
+
 	typedef typename DataPoints::Index Index;
 
 	typedef typename PointMatcher<T>::DataPoints::InvalidField InvalidField;
@@ -73,11 +73,11 @@ public:
 	const std::size_t nbSample;
 	const std::size_t seed;
 	const T epsilon;
-	
+
 	//Ctor, uses parameter interface
 	NormalSpaceDataPointsFilter(const Parameters& params = Parameters());
 	//NormalSpaceDataPointsFilter();
-	
+
 	//Dtor
 	virtual ~NormalSpaceDataPointsFilter() {};
 
@@ -86,8 +86,6 @@ public:
 
 private:
 	inline std::size_t bucketIdx(T theta, T phi) const;
-	
+
 	const std::size_t nbBucket;
 };
-	
-

--- a/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
@@ -222,7 +222,8 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 			if(sortEigen)
 				normals->col(i) = eigenVe.col(0);
 			else
-				normals->col(i) = computeNormal<T>(eigenVa, eigenVe);
+				// clamp normals to [-1,1] to handle approximation errors
+				normals->col(i) = computeNormal<T>(eigenVa, eigenVe).cwiseMax(-1.0).cwiseMin(1.0);
 		}
 		if(keepDensities)
 		{

--- a/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
@@ -50,7 +50,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Constructor
 template<typename T>
 SurfaceNormalDataPointsFilter<T>::SurfaceNormalDataPointsFilter(const Parameters& params):
-	PointMatcher<T>::DataPointsFilter("SurfaceNormalDataPointsFilter", 
+	PointMatcher<T>::DataPointsFilter("SurfaceNormalDataPointsFilter",
 		SurfaceNormalDataPointsFilter::availableParameters(), params),
 	knn(Parametrizable::get<int>("knn")),
 	maxDist(Parametrizable::get<T>("maxDist")),
@@ -68,7 +68,7 @@ SurfaceNormalDataPointsFilter<T>::SurfaceNormalDataPointsFilter(const Parameters
 
 // Compute
 template<typename T>
-typename PointMatcher<T>::DataPoints 
+typename PointMatcher<T>::DataPoints
 SurfaceNormalDataPointsFilter<T>::filter(
 	const DataPoints& input)
 {
@@ -87,7 +87,7 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 	typedef typename DataPoints::Labels Labels;
 	typedef typename MatchersImpl<T>::KDTreeMatcher KDTreeMatcher;
 	typedef typename PointMatcher<T>::Matches Matches;
-	
+
 	using namespace PointMatcherSupport;
 
 	const int pointsCount(cloud.features.cols());
@@ -154,7 +154,7 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 	boost::assign::insert(param) ( "knn", toParam(knn) );
 	boost::assign::insert(param) ( "epsilon", toParam(epsilon) );
 	boost::assign::insert(param) ( "maxDist", toParam(maxDist) );
-	
+
 	KDTreeMatcher matcher(param);
 	matcher.init(cloud);
 
@@ -245,7 +245,7 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 				(*meanDists)(0, i) = (point - mean).norm();
 			}
 		}
-		
+
 	}
 
 	if(keepMatchedIds)


### PR DESCRIPTION
Improves the runtime performance of the normal space filter. Replaces rejection sampling with an equivalent, but more efficient method. Improves runtime determinism as well.  Speed up is from about 3-4 seconds on 35k points down to tens of msecs.