### PR TITLE
Fix/clamp normals

### DIFF
--- a/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
@@ -222,7 +222,8 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 			if(sortEigen)
 				normals->col(i) = eigenVe.col(0);
 			else
-				normals->col(i) = computeNormal<T>(eigenVa, eigenVe);
+				// clamp normals to [-1,1] to handle approximation errors
+				normals->col(i) = computeNormal<T>(eigenVa, eigenVe).cwiseMax(-1.0).cwiseMin(1.0);
 		}
 		if(keepDensities)
 		{

--- a/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
@@ -50,7 +50,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Constructor
 template<typename T>
 SurfaceNormalDataPointsFilter<T>::SurfaceNormalDataPointsFilter(const Parameters& params):
-	PointMatcher<T>::DataPointsFilter("SurfaceNormalDataPointsFilter", 
+	PointMatcher<T>::DataPointsFilter("SurfaceNormalDataPointsFilter",
 		SurfaceNormalDataPointsFilter::availableParameters(), params),
 	knn(Parametrizable::get<int>("knn")),
 	maxDist(Parametrizable::get<T>("maxDist")),
@@ -68,7 +68,7 @@ SurfaceNormalDataPointsFilter<T>::SurfaceNormalDataPointsFilter(const Parameters
 
 // Compute
 template<typename T>
-typename PointMatcher<T>::DataPoints 
+typename PointMatcher<T>::DataPoints
 SurfaceNormalDataPointsFilter<T>::filter(
 	const DataPoints& input)
 {
@@ -87,7 +87,7 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 	typedef typename DataPoints::Labels Labels;
 	typedef typename MatchersImpl<T>::KDTreeMatcher KDTreeMatcher;
 	typedef typename PointMatcher<T>::Matches Matches;
-	
+
 	using namespace PointMatcherSupport;
 
 	const int pointsCount(cloud.features.cols());
@@ -154,7 +154,7 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 	boost::assign::insert(param) ( "knn", toParam(knn) );
 	boost::assign::insert(param) ( "epsilon", toParam(epsilon) );
 	boost::assign::insert(param) ( "maxDist", toParam(maxDist) );
-	
+
 	KDTreeMatcher matcher(param);
 	matcher.init(cloud);
 
@@ -245,7 +245,7 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 				(*meanDists)(0, i) = (point - mean).norm();
 			}
 		}
-		
+
 	}
 
 	if(keepMatchedIds)


### PR DESCRIPTION
Approximation errors sometimes cause the components of the normal vector to be beyond the range of [-1, 1]. Normal components are now clamped to prevent computation errors downstream.