### PR TITLE
Remove O3 during debugging so that assertions are caught

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,10 +62,6 @@ endif (NOT CMAKE_BUILD_TYPE)
 
 
 #================= extra building definitions ==============================
-if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  add_definitions(-O3)
-endif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-
 # For Windows
 if( MSVC ) # VS2012 does not support tuples correctly yet
 	add_definitions( /D _VARIADIC_MAX=10 )


### PR DESCRIPTION
-O3 was set manually when the release type was set to Debug. This prevents assertions used for verification from being handled that are useful for debugging.